### PR TITLE
added margin to the img

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -17,6 +17,10 @@
   justify-content: center;
   flex-wrap: flex;
   padding-right: 20px;
+
+  img {
+    margin-right: 15px;
+  }
 }
 
 main {


### PR DESCRIPTION
fixed the space between the img and the text box on landing page.